### PR TITLE
account for missing functional in WSL in TestByteBuffer

### DIFF
--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -332,6 +332,9 @@ public class TestByteBuffer {
                     assertEquals(byteBuffer.capacity(), segment.byteSize());
                     assertEquals(byteBuffer.isReadOnly(), segment.isReadOnly());
                     assertTrue(byteBuffer.isDirect());
+                } catch(IOException e) {
+                    if (e.getMessage().equals("Function not implemented"))
+                        throw new SkipException(e.getMessage(), e);
                 } finally {
                     if (arena.scope() != Arena.global().scope()) {
                         arena.close();


### PR DESCRIPTION
This test can fail on WSL because `mincore` is not implemented there.

Catch the exception and skip the test in that case. We already do the same for other tests, such as `testLargeMappedSegment`.