### PR TITLE
Add simple HashMapViews microbenchmark

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/HashMapViews.java
+++ b/test/micro/org/openjdk/bench/java/util/HashMapViews.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@State(Scope.Thread)
+public class HashMapViews {
+
+    @Param({"1", "1000"})
+    public int size;
+
+    @Param({"HashMap"})
+    public String mapType;
+
+    private Map<Integer, Integer> map;
+
+    @Setup
+    public void setup() {
+        switch (mapType) {
+            case "HashMap":
+                map = new HashMap<>();
+                break;
+            case "LinkedHashMap":
+                map = new LinkedHashMap<>();
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+        for (int i = 0; i < size; i++) {
+            map.put(i, i * i);
+        }
+    }
+
+    @Benchmark
+    public int keySetSize() {
+        return map.keySet().size();
+    }
+
+    @Benchmark
+    public int valuesSize() {
+        return map.values().size();
+    }
+
+    @Benchmark
+    public int entrySetSize() {
+        return map.entrySet().size();
+    }
+
+}


### PR DESCRIPTION
```
Name                      (size) Cnt  Base   Error   Test   Error   Unit   Diff%
HashMapViews.entrySetSize      1   5 1,085 ± 0,118  1,003 ± 0,053  ns/op    7,6% (p = 0,002*)
  :gc.alloc.rate             N/A   5 0,013 ± 0,000  0,013 ± 0,000 MB/sec   -0,1% (p = 0,639 )
  :gc.alloc.rate.norm        N/A   5 0,000 ± 0,000  0,000 ± 0,000   B/op   -7,7% (p = 0,003*)
  :gc.count                  N/A   5 0,000          0,000         counts
HashMapViews.entrySetSize   1000   5 1,001 ± 0,026  1,033 ± 0,170  ns/op   -3,3% (p = 0,173 )
  :gc.alloc.rate             N/A   5 0,013 ± 0,000  0,013 ± 0,000 MB/sec    0,6% (p = 0,012 )
  :gc.alloc.rate.norm        N/A   5 0,000 ± 0,000  0,000 ± 0,000   B/op    3,9% (p = 0,124 )
  :gc.count                  N/A   5 0,000          0,000         counts
HashMapViews.keySetSize        1   5 1,051 ± 0,017  0,706 ± 0,008  ns/op   32,8% (p = 0,000*)
  :gc.alloc.rate             N/A   5 0,013 ± 0,000  0,013 ± 0,000 MB/sec    0,0% (p = 0,947 )
  :gc.alloc.rate.norm        N/A   5 0,000 ± 0,000  0,000 ± 0,000   B/op  -32,8% (p = 0,000*)
  :gc.count                  N/A   5 0,000          0,000         counts
HashMapViews.keySetSize     1000   5 1,078 ± 0,013  0,705 ± 0,006  ns/op   34,6% (p = 0,000*)
  :gc.alloc.rate             N/A   5 0,013 ± 0,000  0,013 ± 0,000 MB/sec   -0,1% (p = 0,756 )
  :gc.alloc.rate.norm        N/A   5 0,000 ± 0,000  0,000 ± 0,000   B/op  -34,7% (p = 0,000*)
  :gc.count                  N/A   5 0,000          0,000         counts
HashMapViews.valuesSize        1   5 0,998 ± 0,033  0,718 ± 0,062  ns/op   28,1% (p = 0,000*)
  :gc.alloc.rate             N/A   5 0,013 ± 0,000  0,013 ± 0,000 MB/sec    0,7% (p = 0,055 )
  :gc.alloc.rate.norm        N/A   5 0,000 ± 0,000  0,000 ± 0,000   B/op  -27,6% (p = 0,000*)
  :gc.count                  N/A   5 0,000          0,000         counts
HashMapViews.valuesSize     1000   5 1,043 ± 0,062  0,705 ± 0,011  ns/op   32,4% (p = 0,000*)
  :gc.alloc.rate             N/A   5 0,013 ± 0,000  0,013 ± 0,000 MB/sec   -0,3% (p = 0,405 )
  :gc.alloc.rate.norm        N/A   5 0,000 ± 0,000  0,000 ± 0,000   B/op  -32,6% (p = 0,000*)
  :gc.count                  N/A   5 0,000          0,000         counts
  * = significant

Invariant parameters used by above microbenchmarks:
mapType:   HashMap
```