### PR TITLE
Frame use record, use lambda replace CleanupAction

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/BufferStack.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/BufferStack.java
@@ -134,7 +134,11 @@ public final class BufferStack {
             return new PerThread(new ReentrantLock(),
                     arena,
                     new SlicingAllocator(arena.allocate(byteSize, byteAlignment)),
-                    (MemorySegment _) -> Reference.reachabilityFence(arena));
+                    new Consumer<MemorySegment>() {
+                        @Override
+                        public void accept(MemorySegment memorySegment) {
+                            Reference.reachabilityFence(arena);
+                        }});
         }
     }
 


### PR DESCRIPTION
It is unusual to use a nested class in record. Can it be changed to record?

Can CleanupAction be changed to lambda?